### PR TITLE
fix none_string name

### DIFF
--- a/mwrefs/utilities/util.py
+++ b/mwrefs/utilities/util.py
@@ -16,7 +16,7 @@ def tsv_encode(val, none_string="NULL"):
         str -- a string representing the encoded value
     """
     if val == "None":
-        return null_string
+        return none_string
     elif isinstance(val, list) or isinstance(val, dict):
         return json.dumps(val)
     else:


### PR DESCRIPTION
Fix discrepancy between variable names (none_string vs null_string) that causes a NameError